### PR TITLE
Toggles for manual triggers

### DIFF
--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: boolean
         description: Push docker image to the configured registry
-        default: true
+        default: false
       docker_image_tag:
         required: false
         type: string
@@ -84,7 +84,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: ${{ inputs.submodules == 'true' }}
-        if: (inputs.submodules == 'true' || inputs.submodules == 'false')  && github.event_name != 'workflow_dispatch'
+          ref: ${{ inputs.target_branch }}
+        if: (inputs.submodules == 'true' || inputs.submodules == 'false')
 
       # assumes the submodules is a private repo
       - name: git checkout w/ recursive submodules
@@ -93,26 +94,8 @@ jobs:
           fetch-depth: 0
           submodules: ${{ inputs.submodules }}
           token: ${{ secrets.ORG_PAT }}
-        if: inputs.submodules == 'recursive' && github.event_name != 'workflow_dispatch'
-
-      # Follow the same git checkout process with submodules but specify a branch ref if it is a workflow_dispatch build
-      - name: git checkout workflow_dispatch
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: ${{ inputs.submodules == 'true' }}
           ref: ${{ inputs.target_branch }}
-        if: (inputs.submodules == 'true' || inputs.submodules == 'false') && github.event_name == 'workflow_dispatch'
-
-      # assumes the submodules is a private repo
-      - name: git checkout w/ recursive submodules workflow_dispatch
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: ${{ inputs.submodules }}
-          token: ${{ secrets.ORG_PAT }}
-          ref: ${{ inputs.target_branch }}
-        if: inputs.submodules == 'recursive' && github.event_name == 'workflow_dispatch'
+        if: inputs.submodules == 'recursive'
 
       - name: nodejs version
         run: |
@@ -135,7 +118,7 @@ jobs:
             BUILD_VERSION="${{ inputs.docker_image_tag }}"
           fi
           echo "IMAGE=${{ inputs.namespace }}-${{ inputs.app }}:$BUILD_VERSION" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch)) || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch)) || inputs.docker_push == true
         working-directory: ${{ inputs.working_dir }}
 
       # assumes all other pushes are for tags
@@ -178,12 +161,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ inputs.aws_region }}
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
+        if: github.event_name == 'push' || inputs.docker_push == true
 
       - name: registry login
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
+        if: github.event_name == 'push' || inputs.docker_push == true
 
 
       - name: push
@@ -192,7 +175,7 @@ jobs:
         run: |
           docker tag $IMAGE $ECR_REGISTRY/$IMAGE
           docker push $ECR_REGISTRY/$IMAGE
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
+        if: github.event_name == 'push' || inputs.docker_push == true
         working-directory: ${{ inputs.working_dir }}
 
       - name: notify failure

--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -19,6 +19,13 @@ on:
         required: false
         type: string
         default: us-east-2
+      docker_push:
+        required: false
+        description: Push docker image to the configured registry
+        default: true
+      docker_image_tag:
+        required: false
+        description: Provide a docker image tag to use for the docker push
       docker_build_args:
         required: false
         type: string
@@ -85,7 +92,7 @@ jobs:
           token: ${{ secrets.ORG_PAT }}
         if: inputs.submodules == 'recursive' && github.event_name != 'workflow_dispatch'
 
-# Follow the same git checkout process with submodules but specify a branch ref if it is a workflow_dispatch build
+      # Follow the same git checkout process with submodules but specify a branch ref if it is a workflow_dispatch build
       - name: git checkout workflow_dispatch
         uses: actions/checkout@v2
         with:
@@ -119,9 +126,9 @@ jobs:
 
       - name: build version
         run: |
-          BUILD_VERSION="${{ env.PACKAGE_VERSION }}-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
+          BUILD_VERSION="${{ inputs.docker_image_tag }} || ${{ env.PACKAGE_VERSION }}-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
           echo "IMAGE=${{ inputs.namespace }}-${{ inputs.app }}:$BUILD_VERSION" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch)) || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch)) || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
         working-directory: ${{ inputs.working_dir }}
 
       # assumes all other pushes are for tags
@@ -164,12 +171,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ inputs.aws_region }}
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
 
       - name: registry login
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
 
 
       - name: push
@@ -178,7 +185,7 @@ jobs:
         run: |
           docker tag $IMAGE $ECR_REGISTRY/$IMAGE
           docker push $ECR_REGISTRY/$IMAGE
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
         working-directory: ${{ inputs.working_dir }}
 
       - name: notify failure

--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -26,6 +26,7 @@ on:
       docker_image_tag:
         required: false
         description: Provide a docker image tag to use for the docker push
+        default: ""
       docker_build_args:
         required: false
         type: string
@@ -126,7 +127,11 @@ jobs:
 
       - name: build version
         run: |
-          BUILD_VERSION="${{ inputs.docker_image_tag }} || ${{ env.PACKAGE_VERSION }}-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
+          BUILD_VERSION="${{ env.PACKAGE_VERSION }}-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
+          if [[ "${{ inputs.docker_image_tag }}" != "" ]]; then
+            echo "Using the provided docker image tag: ${{ inputs.docker_image_tag }}"
+            BUILD_VERSION="${{ inputs.docker_image_tag }}"
+          fi
           echo "IMAGE=${{ inputs.namespace }}-${{ inputs.app }}:$BUILD_VERSION" >> $GITHUB_ENV
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch)) || (github.event_name == 'workflow_dispatch' && inputs.docker_push == true)
         working-directory: ${{ inputs.working_dir }}

--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -118,7 +118,7 @@ jobs:
             BUILD_VERSION="${{ inputs.docker_image_tag }}"
           fi
           echo "IMAGE=${{ inputs.namespace }}-${{ inputs.app }}:$BUILD_VERSION" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch)) || inputs.docker_push == true
+        if: github.event_name != 'push' || (github.event_name == 'push' && contains(github.ref, inputs.target_branch))
         working-directory: ${{ inputs.working_dir }}
 
       # assumes all other pushes are for tags

--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -21,10 +21,12 @@ on:
         default: us-east-2
       docker_push:
         required: false
+        type: boolean
         description: Push docker image to the configured registry
         default: true
       docker_image_tag:
         required: false
+        type: string
         description: Provide a docker image tag to use for the docker push
         default: ""
       docker_build_args:

--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -84,8 +84,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: ${{ inputs.submodules == 'true' }}
-          ref: ${{ inputs.target_branch }}
-        if: (inputs.submodules == 'true' || inputs.submodules == 'false')
+        if: (inputs.submodules == 'true' || inputs.submodules == 'false')  && github.event_name != 'workflow_dispatch'
 
       # assumes the submodules is a private repo
       - name: git checkout w/ recursive submodules
@@ -94,8 +93,26 @@ jobs:
           fetch-depth: 0
           submodules: ${{ inputs.submodules }}
           token: ${{ secrets.ORG_PAT }}
+        if: inputs.submodules == 'recursive' && github.event_name != 'workflow_dispatch'
+
+      # Follow the same git checkout process with submodules but specify a branch ref if it is a workflow_dispatch build
+      - name: git checkout workflow_dispatch
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: ${{ inputs.submodules == 'true' }}
           ref: ${{ inputs.target_branch }}
-        if: inputs.submodules == 'recursive'
+        if: (inputs.submodules == 'true' || inputs.submodules == 'false') && github.event_name == 'workflow_dispatch'
+
+      # assumes the submodules is a private repo
+      - name: git checkout w/ recursive submodules workflow_dispatch
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: ${{ inputs.submodules }}
+          token: ${{ secrets.ORG_PAT }}
+          ref: ${{ inputs.target_branch }}
+        if: inputs.submodules == 'recursive' && github.event_name == 'workflow_dispatch'
 
       - name: nodejs version
         run: |


### PR DESCRIPTION
- Update the generic script to be more trigger event agnostic 
- Removed checks that can rely on downstream scripts' default behaviour @calbritt would appreciate a close look from you on those `actions/checkout@v2` changes. I think when empty strings are passed as `ref`, that script treat it as not provided. 
- Added an extra parameter to customise docker image tag