### PR TITLE
output image from workflow

### DIFF
--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    outputs:
+      image:
+        description: "pushed image"
+        value: ${{ jobs.build.outputs.image }}
     inputs:
       namespace:
         required: true
@@ -68,6 +72,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.push.outputs.IMAGE }}
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -118,6 +124,7 @@ jobs:
         working-directory: ${{ inputs.working_dir }}
 
       - name: build version
+        id: version
         run: |
           BUILD_VERSION="${{ env.PACKAGE_VERSION }}-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
           if [[ "${{ inputs.docker_image_tag }}" != "" ]]; then
@@ -168,11 +175,13 @@ jobs:
 
 
       - name: push
+        id: push
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           docker tag $IMAGE $ECR_REGISTRY/$IMAGE
           docker push $ECR_REGISTRY/$IMAGE
+          echo "IMAGE=$IMAGE" >> $GITHUB_OUTPUT
         if: github.event_name == 'push' || inputs.docker_push == true
         working-directory: ${{ inputs.working_dir }}
 


### PR DESCRIPTION
so that calling jobs can use it in follow on jobs


tested here -> where I ran ofa branch of this workflow and could access the image in another job eg:
 https://github.com/kaleido-io/firefly-enterprise/actions/runs/4000796667/jobs/6866447859#step:2:5