### PR TITLE
changing calver-timetampt delimiter to _

### DIFF
--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -137,7 +137,7 @@ jobs:
       - name: build version
         id: version
         run: |
-          BUILD_VERSION="${{ env.PACKAGE_VERSION }}-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
+          BUILD_VERSION="${{ env.PACKAGE_VERSION }}_$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER"
           if [[ "${{ inputs.docker_image_tag }}" != "" ]]; then
             echo "Using the provided docker image tag: ${{ inputs.docker_image_tag }}"
             BUILD_VERSION="${{ inputs.docker_image_tag }}"


### PR DESCRIPTION
as discussed in office, parsing (specially as a human readable text) is not straightforward when we have too many arbitrary `-` in the docker image tag. So we decided to use `_` as delimiter in tag `PACKAGEVERSION_DATE-RUNNUMBER` to easily split the tag in two parts.