### PR TITLE
Ensure go version is 1.21

### DIFF
--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -121,6 +121,11 @@ jobs:
           ref: ${{ inputs.target_branch }}
         if: inputs.submodules == 'recursive' && github.event_name == 'workflow_dispatch'
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
       - name: nodejs version
         run: |
           PACKAGE_VERSION=$(jq -r .version package.json)

--- a/.github/workflows/microservice.yml
+++ b/.github/workflows/microservice.yml
@@ -125,6 +125,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+          check-latest: true
 
       - name: nodejs version
         run: |


### PR DESCRIPTION
Various parts of the go tooling (such as `run_component_test`) use the version of `go` on the path - and it doesn't seem to be at 1.21 by default.